### PR TITLE
call Framework.run() as soon as possible when an event is posted to A…

### DIFF
--- a/farc/__init__.py
+++ b/farc/__init__.py
@@ -670,9 +670,13 @@ class Ahsm(Hsm):
 
     def postLIFO(self, evt):
         self.mq.append(evt)
+        # Run to completion
+        Framework._event_loop.call_soon_threadsafe(Framework.run)
 
     def postFIFO(self, evt):
         self.mq.appendleft(evt)
+        # Run to completion
+        Framework._event_loop.call_soon_threadsafe(Framework.run)
 
     def pop_msg(self,):
         return self.mq.pop()


### PR DESCRIPTION
First, I would like to thank you for creating this useful python package.

## Problem
I implement a simple on-off switch using farc. After state machine is started, I post a *flick* event after 2 seconds. However, the *flick* event will not be executed by the state machine. Refer the attached file [on-off-switch.zip](https://github.com/dwhall/farc/files/3548366/on-off-switch.zip) about the example.

Log before change:
```
[2019-08-28 06:33:35.497][on-off-switch            ][L#0019] _initial() - OnOffSwitch _initial
[2019-08-28 06:33:35.497][on-off-switch            ][L#0034] off() - <off> enter
[2019-08-28 06:33:35.498][on-off-switch            ][L#0069] postFlickEvent() - post FLICK event
[2019-08-28 06:33:39.500][on-off-switch            ][L#0069] postFlickEvent() - post FLICK event
```

## Change
`Framework.run()` is implemented with *run-to-completion* execution model. `Framework.run()` will exit if there is event in the queue. In order to make `Framework.run()` to be executed again, I need to call `Framework._event_loop.call_soon_threadsafe(Framework.run)` when an event is posted.

Log after change:
```
[2019-08-28 06:50:50.259][on-off-switch            ][L#0019] _initial() - OnOffSwitch _initial
[2019-08-28 06:50:50.260][on-off-switch            ][L#0034] off() - <off> enter
[2019-08-28 06:50:52.261][on-off-switch            ][L#0069] postFlickEvent() - post FLICK event
[2019-08-28 06:50:52.261][on-off-switch            ][L#0037] off() - <off> flick
[2019-08-28 06:50:52.261][on-off-switch            ][L#0040] off() - <off> exit
[2019-08-28 06:50:52.261][on-off-switch            ][L#0056] on() - <on> enter - turn light on
```

